### PR TITLE
Add clearer documentation on the format of boxes, and normalize lat/long comparisons

### DIFF
--- a/settings.py
+++ b/settings.py
@@ -24,6 +24,7 @@ AREAS = ["eby", "sfc", "sby", "nby"]
 # attached will be checked to see which area it is in.  If there's a match, it will be annotated with the area
 # name.  If no match, the neighborhood field, which is a string, will be checked to see if it matches
 # anything in NEIGHBORHOODS.
+# Format for theses boxes is: ["your box name": [<bottom right lat>, <bottom right long>], [<top left lat>, <top left long>]]
 BOXES = {
     "adams_point": [
         [37.80789, -122.25000],

--- a/util.py
+++ b/util.py
@@ -22,10 +22,10 @@ def in_box(coords, box):
     """
     Find if a coordinate tuple is inside a bounding box.
     :param coords: Tuple containing latitude and longitude.
-    :param box: Two tuples, where first is the bottom left, and the second is the top right of the box.
+    :param box: Two tuples, where first is the bottom right, and the second is the top left of the box.
     :return: Boolean indicating if the coordinates are in the box.
     """
-    if box[0][0] < coords[0] < box[1][0] and box[1][1] < coords[1] < box[0][1]:
+    if box[0][0]+90 < coords[0]+90 < box[1][0]+90 and box[1][1]+180 < coords[1]+180 < box[0][1]+180:
         return True
     return False
 


### PR DESCRIPTION
Love the blog post, documentation, and utility of this!

Was setting it up myself, and had trouble getting results that I thought would be in the boxes when I set up the first inner list to be the bottom left coordinate and the second inner list to be the top right coordinate for the bounding box.

Maybe I am misinterpreting but when I examined the `in_box` method it appears as if the comparison is done using the first inner list as the bottom right, and the second as the top left. I also normalized so that it will work in other quadrants of the lat/long system.

I could be a bit misguided, so let me know if I was simply utilizing the `AREAS` incorrectly. 