### PR TITLE
Allow area to go unspecified / parametrize bot name

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -119,8 +119,11 @@ def do_scrape():
 
     # Get all the results from craigslist.
     all_results = []
-    for area in settings.AREAS:
-        all_results += scrape_area(area)
+    if settings.AREAS:
+        for area in settings.AREAS:
+            all_results += scrape_area(area)
+    else:
+        all_results = scrape_area(None)
 
     print("{}: Got {} results".format(time.ctime(), len(all_results)))
 

--- a/settings.py
+++ b/settings.py
@@ -110,6 +110,9 @@ SLEEP_INTERVAL = 20 * 60 # 20 minutes
 # Which slack channel to post the listings into.
 SLACK_CHANNEL = "#housing"
 
+# Which slack username to use to post
+SLACK_USER = "pybot"
+
 # The token that allows us to connect to slack.
 # Should be put in private.py, or set as an environment variable.
 SLACK_TOKEN = os.getenv('SLACK_TOKEN', "")

--- a/util.py
+++ b/util.py
@@ -38,7 +38,7 @@ def post_listing_to_slack(sc, listing):
     desc = "{0} | {1} | {2} | {3} | <{4}>".format(listing["area"], listing["price"], listing["bart_dist"], listing["name"], listing["url"])
     sc.api_call(
         "chat.postMessage", channel=settings.SLACK_CHANNEL, text=desc,
-        username='pybot', icon_emoji=':robot_face:'
+        username=settings.SLACK_USER, icon_emoji=':robot_face:'
     )
 
 def find_points_of_interest(geotag, location):


### PR DESCRIPTION
Hi, thank you for this extremely useful piece of software! I am moving across the country myself and this could save a lot of time.

While trying to adapt the code to my specific situation, I noticed that the program expects a list of areas to perform the search into. However, Craigslist domains for sparsely populated regions do not have such subdivisions. I made a simple tweak to ignore the area parameter when the area list is empty, and support this use case.

Oh, and I also parametrized the bot name so it can be configured in the settings :-)